### PR TITLE
Fix python-config-wrapper on OSX

### DIFF
--- a/python-config-wrapper
+++ b/python-config-wrapper
@@ -30,6 +30,6 @@ if [ "$1" = "-n" ]; then
 	exit 0
 fi
 
-${PYCFG} $@ | sed -e 's/-arch [^\s]*//g' | \
+${PYCFG} $@ | sed -e 's/-arch [^\ ]*//g' | \
 	sed 's, s ,,g' | \
 	sed s,-Wstrict-prototypes,,g 2>/dev/null


### PR DESCRIPTION
On OSX sed does not support \s for whitespace resulting in
python-config-wrapper removing everything from -arch to the next 's'.
