### PR TITLE
Correct Perl solib extension on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ install-perl:
 	fi ; \
 	mkdir -p $$target/r2 ; \
 	echo "Installing perl r2 modules..." ; \
-	cp -rf perl/*.so $$target/r2 ; \
+	cp -rf perl/*.${SOEXT} $$target/r2 ; \
 	cp -rf perl/*.pm $$target/r2
 
 install-vapi:


### PR DESCRIPTION
On OSX the Perl libraries are named .dylib instead of .so so use ${SOEXT} in
the install-perl rule.
