### PR TITLE
Map type 'Char' to 'byte' in Go bindings

### DIFF
--- a/go/fixgoswig.sh
+++ b/go/fixgoswig.sh
@@ -25,3 +25,4 @@ $ {
 }
 ' $FILE > $FILE.fix
 mv -f $FILE.fix $FILE
+sed -i -e "s/Char/byte/g" "$FILE"


### PR DESCRIPTION
`Char` is not a type in Go. Perhaps there is some mapping magic that will automatically convert this, but I'm not a swig wizard.  If you'd prefer a vanilla swig solution, please point me to a starting point/reference, and I'll happily dig into it.
