### PR TITLE
Use 'go tool' prefix for tools like '6c' and whatnot

### DIFF
--- a/go/goenv.sh
+++ b/go/goenv.sh
@@ -16,9 +16,9 @@ case "${HOST_ARCH}" in
 	;;
 esac
 
-GOC=${GO_N}g
-GOL=${GO_N}l
-GOCC=${GO_N}c
+GOC="go tool ${GO_N}g"
+GOL="go tool ${GO_N}l"
+GOCC="go tool ${GO_N}c"
 GOOS=`uname | tr 'A-Z' 'a-z'`
 GOROOT=/usr/lib/go
 export GOC GOL GOARCH GO_FLAGS GOOS GO_N GOROOT


### PR DESCRIPTION
Although `6l` and friends may be present in some people's $PATH, the correct invocation is `go tool 6l ...` (also, on my box, `6l` is not in my $PATH).

Reference: http://golang.org/cmd/gc/
