### PR TITLE
Use 'int' instead of 'int64' in slice sizes for Go bindings

### DIFF
--- a/go/fixgoswig.sh
+++ b/go/fixgoswig.sh
@@ -10,7 +10,7 @@ $ {
 	s/\(\n\t[^\n(]*([^\n)]*)\) \([a-zA-Z0-9]\+\)Vector/\1 []\2/g
 	s/\(\nfunc ([^\n]*\) \([a-zA-Z0-9]\+\)Vector {\n\treturn \([^\n]*\)\n}/\1 []\2 {\
 	v := \3\
-	n := v.Size()\
+	n := int(v.Size())\
 	if n  <= 0 {\
 		return nil\
 	}\


### PR DESCRIPTION
The `len` function in Go returns an `int`, not an `int64`.

Reference: http://golang.org/ref/spec#Length_and_capacity
