### PR TITLE
Don't overwrite GOROOT environment variable when building Go bindings

### DIFF
--- a/go/goenv.sh
+++ b/go/goenv.sh
@@ -20,5 +20,10 @@ GOC=${GO_N}g
 GOL=${GO_N}l
 GOCC=${GO_N}c
 GOOS=`uname | tr 'A-Z' 'a-z'`
-GOROOT=/usr/lib/go
+if ! "$GOROOT"; then
+	echo "Warning, setting \$GOROOT to '/usr/lib/go', but this should probably be set elsewhere";
+	GOROOT=/usr/lib/go;
+else
+	GOROOT="$GOROOT";
+fi
 export GOC GOL GOARCH GO_FLAGS GOOS GO_N GOROOT


### PR DESCRIPTION
$GOROOT is one of the environment variables that pretty much has to already be set to use Go. So, `goenv.sh` should auto-detect if its set and try not to overwrite it. Otherwise, it might be helpful to warn the user.
