### PR TITLE
vapi: r_util: remove reference to R_LIB_TYPE_CMD

### DIFF
--- a/vapi/r_util.vapi
+++ b/vapi/r_util.vapi
@@ -243,7 +243,6 @@ namespace Radare {
 		SYSCALL,
 		FASTCALL,
 		CRYPTO,
-		CMD,
 		LAST
 	}
 }


### PR DESCRIPTION
While creating some new bindings, discovered that `R_LIB_TYPE_CMD` is no longer a valid enum value, though it is referenced in `r_util.vapi`:`Radare.RLibType`. This removes the entry in the vapi.
