### PR TITLE
Fix: 'make vdoc' failed due to a using statement

### DIFF
--- a/vapi/r_core.vapi
+++ b/vapi/r_core.vapi
@@ -1,7 +1,5 @@
 /* radare - LGPL - Copyright 2009-2014 - pancake */
 
-using SDB;
-
 namespace Radare {
 [Compact]
 [CCode (cheader_filename="r_flags.h,r_anal.h,r_core.h,r_bin.h,r_parse.h,r_lang.h,r_sign.h,r_reg.h,r_list.h,r_types_base.h", cname="RCore", free_function="r_core_free", cprefix="r_core_")]
@@ -84,7 +82,7 @@ public class RCore {
 #if VALABIND_CTYPES
 	public void *sdb;
 #else
-	public Sdb sdb;
+	public SDB.Sdb sdb;
 #endif
 // rtr_n ...
 	// TODO: public RVm vm;


### PR DESCRIPTION
'using SDB' brings the SDB namespace into scope which then clashes with
a subsequent 'namespace SDB' apparently
