### PR TITLE
Display readme in PyPi

### DIFF
--- a/r2pipe/python/README.rst
+++ b/r2pipe/python/README.rst
@@ -4,7 +4,7 @@ r2pipe for Python
 Interact with radare2 using the #!pipe command or in standalone scripts
 that communicate with local or remoate r2 via pipe, tcp or http.
 
-Usage example:
+Usage example::
 
     $ python
     > import r2pipe

--- a/r2pipe/python/README.rst
+++ b/r2pipe/python/README.rst
@@ -10,6 +10,3 @@ Usage example:
     > import r2pipe
     > r2 = r2pipe.open("/bin/ls")
     > print(r2.cmd("pd 10"))
-
-.. Author:: pancake <pancake@nopcode.org>
-.. Project:: http://www.radare.org/

--- a/r2pipe/python/setup.py
+++ b/r2pipe/python/setup.py
@@ -1,11 +1,15 @@
 from distutils.core import setup
 import r2pipe
 
+with open('README.rst') as readme_file:
+    readme = readme_file.read()
+
 setup(
     name='r2pipe',
     version=r2pipe.version(),
     license='MIT',
     description='Pipe interface for radare2',
+    long_description=readme,
     author='pancake',
     author_email='pancake@nopcode.org',
     url='http://rada.re',

--- a/r2pipe/python/setup.py
+++ b/r2pipe/python/setup.py
@@ -2,13 +2,13 @@ from distutils.core import setup
 import r2pipe
 
 setup (
-	name='r2pipe',
-	version=r2pipe.version(),
-	license='MIT',
-	description='Pipe interface for radare2',
-	author='pancake',
-	author_email='pancake@nopcode.org',
-	url='http://rada.re',
-	package_dir={'r2pipe': 'r2pipe'},
-	packages=['r2pipe']
+    name='r2pipe',
+    version=r2pipe.version(),
+    license='MIT',
+    description='Pipe interface for radare2',
+    author='pancake',
+    author_email='pancake@nopcode.org',
+    url='http://rada.re',
+    package_dir={'r2pipe': 'r2pipe'},
+    packages=['r2pipe']
 )

--- a/r2pipe/python/setup.py
+++ b/r2pipe/python/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 import r2pipe
 
-setup (
+setup(
     name='r2pipe',
     version=r2pipe.version(),
     license='MIT',


### PR DESCRIPTION
This PR updates `setup.py` long description field to include the content of `README.rst`, so that it's displayed in the project PyPi page.

An example of the how it would look once uploaded can be found in the following link:
https://testpypi.python.org/pypi/r2pipe/