### PR TITLE
fix build for no libtcc case

### DIFF
--- a/libr/lang/p/Makefile
+++ b/libr/lang/p/Makefile
@@ -58,8 +58,8 @@ ifeq ($(HAVE_LIB_TCC),1)
 lang_tcc.${EXT_SO}: tcc.o
 	-${CC} ${CFLAGS} -fPIC ${LDFLAGS_LIB} -o lang_tcc.${EXT_SO} tcc.c -ldl -ltcc
 else
-lang_tcc.${EXT_SO}:
-	@:# do nothing
+lang_tcc.${EXT_SO}: ;
+	# do nothing
 endif
 
 lang_duktape.$(EXT_SO): duktape.o duk


### PR DESCRIPTION
if HAVE_LIB_TCC == 0, make will call sh and it will fail trying to execute the command # 

 make --trace                                                               
Makefile:46: update target 'all' due to: supported.langs
make -C libr/lang/p
Makefile:62: target 'lang_tcc.so' does not exist
:# do nothing
/bin/sh: :#: command not found
Makefile:62: recipe for target 'lang_tcc.so' failed
make[1]: *** [lang_tcc.so] Error 127
Makefile:46: recipe for target 'all' failed
make: *** [all] Error 2


This patch correct this behaviour by defining an empty make rule described in 
https://www.gnu.org/software/make/manual/html_node/Empty-Recipes.html