### PR TITLE
force json to be str type

### DIFF
--- a/r2pipe/python/r2pipe/__init__.py
+++ b/r2pipe/python/r2pipe/__init__.py
@@ -206,7 +206,7 @@ class open:
 			Returns a Python object respresenting the parsed JSON
 		"""
 		try:
-			data = json.loads(self.cmd(cmd))
+			data = json.loads(self.cmd(cmd).encode('utf-8', 'ignore'))
 		except (ValueError, KeyError, TypeError) as e:
 			sys.stderr.write ("r2pipe.cmdj.Error: %s\n"%(e))
 			data = None


### PR DESCRIPTION
before it would be type 'unicode' on py2.7

closes #81