### PR TITLE
libr: lang: p: Install radare.lua

### DIFF
--- a/libr/lang/p/Makefile
+++ b/libr/lang/p/Makefile
@@ -93,6 +93,7 @@ R2_PLUGIN_PATH=$(shell r2 -nqc 'e dir.plugins' -)
 install:
 	mkdir -p $(DESTDIR)/$(R2_PLUGIN_PATH)
 	[ -n "`ls *.$(EXT_SO)`" ] && cp -f *.$(EXT_SO) $(DESTDIR)/$(R2_PLUGIN_PATH) || true
+	cp -f radare.lua $(DESTDIR)/$(R2_PLUGIN_PATH)
 
 install-home:
 	mkdir -p ~/.config/radare2/plugins


### PR DESCRIPTION
Install radare.lua into R2_PLUGIN_PATH so that r2 won't report the
following error on startup:

    status=6, cannot open $R2_PLUGIN_PATH/radare2/0.10.1/radare.lua: No such file or directory