### PR TITLE
r2pipe/nodejs: fix console.error on null exit code

### DIFF
--- a/r2pipe/nodejs/index.js
+++ b/r2pipe/nodejs/index.js
@@ -234,7 +234,7 @@ function r2bind(ls, cb, r2cmd) {
 
     ls.on('close', function(code) {
       running = false;
-      if (code !== 0 && r2cmd.toString().indexOf('httpCmd') == -1) {
+      if (code && r2cmd.toString().indexOf('httpCmd') == -1) {
         console.log('r2pipe: child process exited with code ' + code);
       }
     });


### PR DESCRIPTION
when the r2 process doesn't exit on its own, `code` will be `null`. Checking whether `code` is truthy accounts for `0` and `null`.