### PR TITLE
[r2pipe] Dotnet r2pipe more platform-agnostic

### DIFF
--- a/r2pipe/dotnet/Makefile
+++ b/r2pipe/dotnet/Makefile
@@ -26,7 +26,7 @@ clean:
 	rm -f main.exe http.exe $(R2P_LIB)
 
 nuget:
-	$(NUGET) pack r2pipe/r2pipe.csproj
+	$(NUGET) pack r2pipe/r2pipe.csproj.nuspec
 
 indent:
 	for a in *.cs ; do $(MONO) $(NARRANGE) $$a ; done

--- a/r2pipe/dotnet/r2pipe/RlangPipe.cs
+++ b/r2pipe/dotnet/r2pipe/RlangPipe.cs
@@ -16,9 +16,8 @@ namespace r2pipe
 #if __MonoCS__
         UnixStream ureadStream;
         UnixStream uwriteStream;
-#else
-        NamedPipeClientStream inclient;
 #endif
+        NamedPipeClientStream inclient;
         StreamReader reader;
         StreamWriter writer;
 
@@ -28,17 +27,23 @@ namespace r2pipe
         public RlangPipe()
         {
 #if __MonoCS__
-// XXX what if running mono on windows?
+			if(Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX) {
+
             ureadStream = new UnixStream(int.Parse(Environment.GetEnvironmentVariable("R2PIPE_IN")));
             reader = new StreamReader(ureadStream);
            
             uwriteStream = new UnixStream(int.Parse(Environment.GetEnvironmentVariable("R2PIPE_OUT")));
             writer = new StreamWriter(uwriteStream);
-#else
+
+			}
+			else {
+#endif
             // Using named pipes on windows. I like this.
             inclient = new NamedPipeClientStream("R2PIPE_PATH");
             reader = new StreamReader(inclient);
             writer = new StreamWriter(inclient);
+#if __MonoCS__
+			}
 #endif
         }
 
@@ -102,10 +107,15 @@ namespace r2pipe
             reader.Dispose();
             writer.Dispose();
 #if __MonoCS__
-            ureadStream.Dispose();
-            uwriteStream.Dispose();
-#else
+			if(Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX) {
+	            ureadStream.Dispose();
+	            uwriteStream.Dispose();
+			}
+			else {
+#endif
             inclient.Dispose();
+#if __MonoCS__
+			}
 #endif
         }
     }

--- a/r2pipe/dotnet/r2pipe/RlangPipe.cs
+++ b/r2pipe/dotnet/r2pipe/RlangPipe.cs
@@ -27,7 +27,7 @@ namespace r2pipe
         public RlangPipe()
         {
 #if __MonoCS__
-			if(Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX) {
+            if(Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX) {
 
             ureadStream = new UnixStream(int.Parse(Environment.GetEnvironmentVariable("R2PIPE_IN")));
             reader = new StreamReader(ureadStream);
@@ -35,15 +35,15 @@ namespace r2pipe
             uwriteStream = new UnixStream(int.Parse(Environment.GetEnvironmentVariable("R2PIPE_OUT")));
             writer = new StreamWriter(uwriteStream);
 
-			}
-			else {
+            }
+            else {
 #endif
             // Using named pipes on windows. I like this.
             inclient = new NamedPipeClientStream("R2PIPE_PATH");
             reader = new StreamReader(inclient);
             writer = new StreamWriter(inclient);
 #if __MonoCS__
-			}
+            }
 #endif
         }
 
@@ -107,15 +107,15 @@ namespace r2pipe
             reader.Dispose();
             writer.Dispose();
 #if __MonoCS__
-			if(Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX) {
-	            ureadStream.Dispose();
-	            uwriteStream.Dispose();
-			}
-			else {
+            if(Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX) {
+                ureadStream.Dispose();
+                uwriteStream.Dispose();
+            }
+            else {
 #endif
             inclient.Dispose();
 #if __MonoCS__
-			}
+            }
 #endif
         }
     }

--- a/r2pipe/dotnet/r2pipe/r2pipe.csproj
+++ b/r2pipe/dotnet/r2pipe/r2pipe.csproj
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{D5B3F257-E13E-42B5-A77E-AA0F809311FD}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -37,6 +37,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="Mono.Posix" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CmdQueue.cs" />
@@ -47,6 +48,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueuedR2Pipe.cs" />
     <Compile Include="R2Pipe.cs" />
+    <Compile Include="RlangPipe.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/r2pipe/dotnet/r2pipe/r2pipe.csproj.nuspec
+++ b/r2pipe/dotnet/r2pipe/r2pipe.csproj.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>r2pipe\r2pipe.csproj</id>
+    <id>r2pipe</id>
     <version>1.0.0</version>
     <authors>radare2</authors>
     <owners>radare2</owners>
@@ -12,5 +12,11 @@
     <releaseNotes></releaseNotes>
     <copyright>Copyright 2015</copyright>
     <tags>radare2 r2pipe</tags>
+    <dependencies>
+      <dependency id="Mono.Posix" version="4.0.0" />
+    </dependencies>
   </metadata>
+  <files>
+      <file src="bin/Release/r2pipe.dll" target="lib" />
+  </files>
 </package>


### PR DESCRIPTION
r2pipe/dotnet is now platform agnostic in a sense that if compiled with
mono, a universal binary that can be used both on windows and linux/osx.