### PR TITLE
[r2pipe/dotnet] Added a PCL version of the r2pipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ r2pipe/.*
 *node_modules*
 ocaml/*.cxx
 ocaml/r_*.ml*
+r2pipe/dotnet/**/*.snk

--- a/r2pipe/dotnet/r2pipe-portable/Properties/AssemblyInfo.cs
+++ b/r2pipe/dotnet/r2pipe-portable/Properties/AssemblyInfo.cs
@@ -1,0 +1,30 @@
+﻿using System.Resources;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// Allgemeine Informationen über eine Assembly werden über folgende 
+// Attribute gesteuert. Ändern Sie diese Attributwerte, um die Informationen zu ändern,
+// die einer Assembly zugeordnet sind.
+[assembly: AssemblyTitle("r2pipe-portable")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("r2pipe-portable")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("de")]
+
+// Versionsinformationen für eine Assembly bestehen aus den folgenden vier Werten:
+//
+//      Hauptversion
+//      Nebenversion 
+//      Buildnummer
+//      Revision
+//
+// Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
+// übernehmen, indem Sie "*" eingeben:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/r2pipe/dotnet/r2pipe-portable/r2pipe-portable.csproj
+++ b/r2pipe/dotnet/r2pipe-portable/r2pipe-portable.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{73640705-0261-4565-9170-8D413E881B41}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>r2pipe_portable</RootNamespace>
+    <AssemblyName>r2pipe-portable</AssemblyName>
+    <DefaultLanguage>de-DE</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;PORTABLE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;PORTABLE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>r2pipe.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+    <None Include="r2pipe.snk" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\r2pipe\CmdQueue.cs">
+      <Link>CmdQueue.cs</Link>
+    </Compile>
+    <Compile Include="..\r2pipe\HttpR2Pipe.cs">
+      <Link>HttpR2Pipe.cs</Link>
+    </Compile>
+    <Compile Include="..\r2pipe\IR2Pipe.cs">
+      <Link>IR2Pipe.cs</Link>
+    </Compile>
+    <Compile Include="..\r2pipe\QueuedR2Pipe.cs">
+      <Link>QueuedR2Pipe.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/r2pipe/dotnet/r2pipe.csproj.nuspec
+++ b/r2pipe/dotnet/r2pipe.csproj.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>r2pipe</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <authors>radare2</authors>
     <owners>radare2</owners>
     <licenseUrl>https://github.com/radare/radare2-bindings/blob/master/COPYING</licenseUrl>
@@ -13,10 +13,17 @@
     <copyright>Copyright 2015</copyright>
     <tags>radare2 r2pipe</tags>
     <dependencies>
-      <dependency id="Mono.Posix" version="4.0.0" />
+      <!-- Everything but... -->
+      <group targetFramework="net40">
+        <dependency id="Mono.Posix" version="4.0.0" />
+      </group>
+      <!-- ... profile 111 for xamarin -->
+      <group targetFramework="netstandard1.1">
+      </group>
     </dependencies>
   </metadata>
   <files>
-      <file src="bin/Release/r2pipe.dll" target="lib" />
+    <file src="r2pipe-portable/bin/Release/r2pipe-portable.dll" target="lib\netstandard1.1" />
+    <file src="r2pipe/bin/Release/r2pipe.dll" target="lib\net40\r2pipe.dll" />
   </files>
 </package>

--- a/r2pipe/dotnet/r2pipe.sln
+++ b/r2pipe/dotnet/r2pipe.sln
@@ -1,13 +1,14 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "r2pipe", "r2pipe\r2pipe.csproj", "{D5B3F257-E13E-42B5-A77E-AA0F809311FD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HttpExample", "HttpExample\HttpExample.csproj", "{46CDE875-0070-4E62-B38D-267375321570}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LocalExample", "LocalExample\LocalExample.csproj", "{AAD0715E-0E37-4904-B54C-61DBC24BCD3A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "r2pipe-portable", "r2pipe-portable\r2pipe-portable.csproj", "{73640705-0261-4565-9170-8D413E881B41}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +28,10 @@ Global
 		{AAD0715E-0E37-4904-B54C-61DBC24BCD3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AAD0715E-0E37-4904-B54C-61DBC24BCD3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AAD0715E-0E37-4904-B54C-61DBC24BCD3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73640705-0261-4565-9170-8D413E881B41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73640705-0261-4565-9170-8D413E881B41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73640705-0261-4565-9170-8D413E881B41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73640705-0261-4565-9170-8D413E881B41}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/r2pipe/dotnet/r2pipe/HttpR2Pipe.cs
+++ b/r2pipe/dotnet/r2pipe/HttpR2Pipe.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -17,7 +18,7 @@ namespace r2pipe
         /// </summary>
         internal Uri uri;
 
-        protected WebClient client = new WebClient();
+        protected HttpClient client = new HttpClient();
 
 
         /// <summary>
@@ -52,7 +53,7 @@ namespace r2pipe
         /// </returns>
         public string RunCommand(string command)
         {
-            return client.DownloadString(new Uri(uri, command));
+            return client.GetStringAsync(new Uri(uri, command)).Result;
         }
 
 #if !OLDNETFX
@@ -65,7 +66,7 @@ namespace r2pipe
         /// </returns>
         public async Task<string> RunCommandAsync(string command)
         {
-            return await client.DownloadStringTaskAsync(new Uri(uri, "/" + command));
+            return await client.GetStringAsync(new Uri(uri, "/" + command));
         }
 #endif
 

--- a/r2pipe/dotnet/r2pipe/QueuedR2Pipe.cs
+++ b/r2pipe/dotnet/r2pipe/QueuedR2Pipe.cs
@@ -12,6 +12,7 @@ namespace r2pipe
 
         private bool iOpenedPipe = false;
 
+#if !PORTABLE
         /// <summary>
         /// Initializes a new instance of the <see cref="QueuedR2Pipe"/> class.
         /// </summary>
@@ -21,6 +22,7 @@ namespace r2pipe
         {
             iOpenedPipe = true;
         }
+#endif
 
         /// <summary>
         /// Initializes a new instance of the <see cref="QueuedR2Pipe"/> class, using a HttpR2Pipe.
@@ -40,6 +42,7 @@ namespace r2pipe
             this.pipe = pipe;
         }
 
+#if !PORTABLE
         /// <summary>
         /// Initializes a new instance of the <see cref="QueuedR2Pipe"/> class.
         /// </summary>
@@ -48,6 +51,7 @@ namespace r2pipe
         {
             iOpenedPipe = true;
         }
+#endif
 
         /// <summary>
         /// Executes the commands.

--- a/r2pipe/dotnet/r2pipe/r2pipe.csproj
+++ b/r2pipe/dotnet/r2pipe/r2pipe.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -11,6 +11,8 @@
     <AssemblyName>r2pipe</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\..\..\..\r2pipe.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,6 +34,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
I've added a PCL version of the r2pipe for dotnet. It needs at least
.NET Standard 1.1, als known as Profile111.