### PR TITLE
fixes build issues for r2pipe 0.8.4 on python3

### DIFF
--- a/r2pipe/python/r2pipe/__init__.py
+++ b/r2pipe/python/r2pipe/__init__.py
@@ -99,7 +99,7 @@ class open:
 			Returns an object with methods to interact with r2 via commands
 		"""
 		if in_rlang():
-			print "RLANG IS SET"
+			print ("RLANG IS SET")
 			self._cmd = self._cmd_rlang
 			return
 		self._cmd = self._cmd_rlang


### PR DESCRIPTION
This fixes an issue with a print statement that was missing parens and caused the build to fail on python3