### PR TITLE
Link lang_python.so with r_io.so

### DIFF
--- a/libr/lang/p/Makefile
+++ b/libr/lang/p/Makefile
@@ -21,7 +21,7 @@ LUA_LDFLAGS+=$(shell pkg-config --libs ${LUAPKG})
 endif
 
 BINDEPS=
-LDFLAGS_LIB=$(shell pkg-config --libs-only-L r_core) -lr_core -lr_util -shared
+LDFLAGS_LIB=$(shell pkg-config --libs-only-L r_core) -lr_core -lr_io -lr_util -shared
 
 LANGS=$(shell ./getlangs.sh ${EXT_SO})
 #LANGS=lang_python.${EXT_SO} lang_perl.${EXT_SO}


### PR DESCRIPTION
When compiling with `LDFLAGS=-Wl,-no-undefined`, the build currently fails
in libr/lang/p with:

    cc python.c -I/usr/include/libr -Wall -DPREFIX=\"/usr\" -I. -Iduk
    -I/usr/include/texluajit -I/usr/include/texlua52
    -I/usr/include/lua5.1 -I/usr/include/lua5.2 -I/usr/include/python2.7
    -I/usr/include/python2.7  -march=x86-64 -mtune=generic -O2 -pipe
    -fstack-protector-strong -DNDEBUG -march=x86-64 -mtune=generic -O2
    -pipe -fstack-protector-strong -lpython2.7 -lpthread -ldl -lutil -lm
    -L/usr/lib  -lr_core -lr_util -shared \
    -Wl,-no-undefined -lr_core -lr_util -shared -fPIC -o lang_python.so
    /tmp/cc2iLJ6E.o: In function `py_io_open':
    python.c:(.text+0x738): undefined reference to `r_io_desc_new'
    collect2: error: ld returned 1 exit status

Because `libr/lang/p/python/io.c` uses the function `r_io_desc_new`,
`lang_python.so` needs to be linked with `r_io.so`.