### PR TITLE
python3 for lang-python

### DIFF
--- a/libr/lang/p/Makefile
+++ b/libr/lang/p/Makefile
@@ -47,6 +47,7 @@ lang_python.${EXT_SO}:
 	${LDFLAGS_LIB} -o lang_python.${EXT_SO} python.c -lpython27
 else
 PYCFG=../../../python-config-wrapper
+PYCFG=python-config
 PYCFLAGS=$(shell ${PYCFG} --cflags)
 PYLDFLAGS=$(shell ${PYCFG} --libs) -L$(shell ${PYCFG} --prefix)/lib ${LDFLAGS_LIB}
 

--- a/libr/lang/p/python/core.c
+++ b/libr/lang/p/python/core.c
@@ -10,8 +10,8 @@ static int py_core_call(void *user, const char *str) {
 	if (py_core_call_cb) {
 		PyObject *arglist = Py_BuildValue ("(z)", str);
 		PyObject *result = PyEval_CallObject (py_core_call_cb, arglist);
-		if (result && PyInt_Check (result)) {
-			return PyInt_AsLong (result);
+		if (result && PyLong_Check (result)) {
+			return PyLong_AsLong (result);
 		}
 	}
 	return 0;

--- a/libr/lang/p/python/io.c
+++ b/libr/lang/p/python/io.c
@@ -14,11 +14,11 @@ static RIODesc* py_io_open(RIO *io, const char *path, int rw, int mode) {
 		PyObject *arglist = Py_BuildValue ("(zii)", path, rw, mode);
 		PyObject *result = PyEval_CallObject (py_io_open_cb, arglist);
 		if (result) {
-			if (PyInt_Check (result)) {
-				if (PyInt_AsLong (result) == -1) {
+			if (PyLong_Check (result)) {
+				if (PyLong_AsLong (result) == -1) {
 					return NULL;
 				}
-				fd = PyInt_AsLong (result);
+				fd = PyLong_AsLong (result);
 			}
 			if (PyBool_Check (result) && result == Py_False) {
 				return NULL;
@@ -46,8 +46,8 @@ static ut64 py_io_seek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 	if (py_io_seek_cb) {
 		PyObject *arglist = Py_BuildValue ("(Ki)", offset, whence);
 		PyObject *result = PyEval_CallObject (py_io_seek_cb, arglist);
-		if (result && PyInt_Check (result)) {
-			return io->off = PyInt_AsLong (result);
+		if (result && PyLong_Check (result)) {
+			return io->off = PyLong_AsLong (result);
 		}
 		if (result && PyLong_Check (result)) {
 			ut64 num = PyLong_AsLongLong (result);
@@ -70,8 +70,8 @@ static int py_io_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 		PyObject *arglist = Py_BuildValue ("(Ki)", io->off, count);
 		PyObject *result = PyEval_CallObject (py_io_read_cb, arglist);
 		if (result) {
-			if (PyString_Check (result)) {
-				int size = PyString_Size (result);
+			if (PyBytes_Check (result)) {
+				int size = PyBytes_Size (result);
 				int limit = R_MIN (size, count);
 				memset (buf, io->Oxff, limit);
 				memcpy (buf, PyString_AsString (result), limit);
@@ -104,8 +104,8 @@ static int py_io_system(RIO *io, RIODesc *desc, const char *cmd) {
 			if (PyBool_Check (result)) {
 				return result == Py_True;
 			}
-			if (PyInt_Check (result)) {
-				return PyInt_AsLong (result);
+			if (PyLong_Check (result)) {
+				return PyLong_AsLong (result);
 			}
 		}
 		// PyObject_Print(result, stderr, 0);

--- a/libr/lang/p/test-py-asm.py
+++ b/libr/lang/p/test-py-asm.py
@@ -11,15 +11,15 @@ import r2lang
 
 def pyasm(a):
 	def assemble(s):
-		print "Assembling %s"%(s)
+		print("Assembling %s"%(s))
 		return [ 1, 2, 3, 4 ]
 
 	def disassemble(buf):
 		try:
 			return [ 2, "opcode %d"%(ord(buf[0])) ]
 		except:
-			print "err"
-			print sys.exc_info()
+			print("err")
+			print(sys.exc_info())
 			return [ 2, "opcode" ]
 	return {
 		"name": "MyPyDisasm",
@@ -31,5 +31,5 @@ def pyasm(a):
 		"disassemble": disassemble,
 	}
 
-print "Registering Python asm plugin..."
-print r2lang.plugin("asm", pyasm)
+print("Registering Python asm plugin...")
+print(r2lang.plugin("asm", pyasm))

--- a/libr/lang/p/test-py-core.py
+++ b/libr/lang/p/test-py-core.py
@@ -13,7 +13,7 @@ import r2lang
 def pycore(a):
 	def _call(s):
 		if s == "q":
-			print "Dont be rude"
+			print("Dont be rude")
 			return 1;
 		return 0
 
@@ -24,5 +24,5 @@ def pycore(a):
 		"call": _call,
 	}
 
-print "Registering Python core plugin..."
-print r2lang.plugin("core", pycore)
+print("Registering Python core plugin...")
+print(r2lang.plugin("core", pycore))

--- a/libr/lang/p/test-py-io.py
+++ b/libr/lang/p/test-py-io.py
@@ -16,16 +16,16 @@ FAKESIZE = 512
 
 def pyio(a):
 	def _open(path, rw, perm):
-		print "MyPyIO Opening %s"%(path)
+		print("MyPyIO Opening %s"%(path))
 		return 1234 
 	def _check(path, many):
-		print "python-check %s"%(path)
+		print("python-check %s"%(path))
 		return path[0:7] == "pyio://"
 	def _read(offset, size):
-		print "python-read"
+		print("python-read")
 		return "A" * size
 	def _seek(offset, whence):
-		print "python-seek"
+		print("python-seek")
 		if whence == 0: # SET
 			return offset
 		if whence == 1: # CUR
@@ -34,10 +34,10 @@ def pyio(a):
 			return 512 
 		return 512
 	def _write(offset, data, size):
-		print "python-write"
+		print("python-write")
 		return True
 	def _system(cmd):
-		print "python-SYSTEM %s"%(cmd)
+		print("python-SYSTEM %s"%(cmd))
 		return True
 	return {
 		"name": "pyio",
@@ -51,5 +51,5 @@ def pyio(a):
 		"system": _system,
 	}
 
-print "Registering Python IO plugin..."
-print r2lang.plugin("io", pyio)
+print("Registering Python IO plugin...")
+print(r2lang.plugin("io", pyio))


### PR DESCRIPTION
since `python-config-wrapper` seems to prevent I from using py3's python-config, currently I manually add `PYCFG=python-config` (it's 3 on my system) to the libr/lang/p/Makefile, temporally.