### PR TITLE
fix build

### DIFF
--- a/libr/lang/p/Makefile
+++ b/libr/lang/p/Makefile
@@ -2,6 +2,7 @@ BINDEPS=foo
 include ../../../config.mk
 
 CFLAGS+=$(shell pkg-config --cflags r_core)
+CFLAGS+=-DPREFIX=\"${PREFIX}\"
 
 DUK_CFLAGS+=-Wall -DPREFIX=\"${PREFIX}\" -I. -Iduk
 


### PR DESCRIPTION
Hello! This PR fixes that `lua.c` fails to build because PREFIX is not defined.

This error was introduced with dd7487eae417a820e15f67c92d4e4eaa4a45f3db.