### PR TITLE
Fix for error: no matching function for call to 'r_meta_del'

### DIFF
--- a/vapi/r_anal.vapi
+++ b/vapi/r_anal.vapi
@@ -496,8 +496,8 @@ namespace Radare {
 	//public string get_string(MetaType, uint64 addr);
 	[CCode (cname="r_meta_add")]
 	public bool meta_add(MetaType type, uint64 from, uint64 size, string str);
-	[CCode (cname="r_meta_del")]
-	public bool meta_del(MetaType type, uint64 from, uint64 size, string str);
+	//[CCode (cname="r_meta_del")]
+	//public bool meta_del(MetaType type, uint64 from, uint64 size, string str);
 	[CCode (cname="r_meta_find")]
 	public MetaItem meta_find(uint64 off, MetaType type, MetaWhere where);
 	[CCode (cname="r_meta_cleanup")]


### PR DESCRIPTION
Fix for issue #177.