### PR TITLE
more useful syntax error for lua plugin

### DIFF
--- a/libr/lang/p/lua.c
+++ b/libr/lang/p/lua.c
@@ -105,7 +105,7 @@ static int lua_run(RLang *lang, const char *code, int len) {
 	if (len == 0) len = strlen (code);
 	luaL_loadbuffer (L, code, len, ""); // \n included
 	if (lua_pcall (L, 0, 0, 1) != 0) {
-		eprintf ("syntax error: %s in %s\n",
+		eprintf ("syntax error(lang_lua): %s in %s\n",
                  lua_tostring(L, -1), code);
 	}
 	clearerr (stdin);

--- a/libr/lang/p/lua.c
+++ b/libr/lang/p/lua.c
@@ -105,8 +105,8 @@ static int lua_run(RLang *lang, const char *code, int len) {
 	if (len == 0) len = strlen (code);
 	luaL_loadbuffer (L, code, len, ""); // \n included
 	if (lua_pcall (L, 0, 0, 1) != 0) {
-		eprintf ("syntax error: %s\n",
-                 lua_tostring(L, -1));
+		eprintf ("syntax error: %s in %s\n",
+                 lua_tostring(L, -1), code);
 	}
 	clearerr (stdin);
 	//lua_close(L); // TODO


### PR DESCRIPTION
currently when there is an error with lua code, even something like required modules not being found the error returned is "syntax error: error in error handling", this patch will print the code the error occured in.

this was the error that was seen in #9111 and #4793 and the issue is missing modules, homebrew lua doesn't contain json.lua and the homebrew radare script doesn't install it either (although json.lua is included in radare2-bindings), and there is also an issue with r_core, i assume the 3rd line that was seen by homebrew users was caused by the next line running and expecting r_core to be accessible.