### PR TITLE
Fix use-after-free bug in py_disassemble

### DIFF
--- a/libr/lang/p/python/asm.c
+++ b/libr/lang/p/python/asm.c
@@ -54,7 +54,7 @@ static int py_assemble(RAsm *a, RAsmOp *op, const char *str) {
 static int py_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	int size = 0;
 	int seize = -1;
-	r_strbuf_set (&op->buf_asm, opstr);
+	r_strbuf_set (&op->buf_asm, "invalid");
 	if (py_disassemble_cb) {
 		PyObject *arglist = Py_BuildValue ("(y#K)", buf, len, a->pc);
 		PyObject *result = PyEval_CallObject (py_disassemble_cb, arglist);
@@ -68,7 +68,6 @@ static int py_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	}
 	r_asm_op_init (op);
 	op->size = size = seize;
-	r_strbuf_set (&op->buf_asm, opstr);
 	int buflen = R_MAX (1, op->size);
 	buflen = R_MIN (buflen, len);
 	char *res = calloc (buflen, 3);

--- a/libr/lang/p/python/asm.c
+++ b/libr/lang/p/python/asm.c
@@ -54,6 +54,7 @@ static int py_assemble(RAsm *a, RAsmOp *op, const char *str) {
 static int py_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	int size = 0;
 	int seize = -1;
+	r_asm_op_init (op);
 	r_strbuf_set (&op->buf_asm, "invalid");
 	if (py_disassemble_cb) {
 		PyObject *arglist = Py_BuildValue ("(y#K)", buf, len, a->pc);
@@ -66,7 +67,6 @@ static int py_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 			Py_DECREF (result);
 		}
 	}
-	r_asm_op_init (op);
 	op->size = size = seize;
 	int buflen = R_MAX (1, op->size);
 	buflen = R_MIN (buflen, len);

--- a/libr/lang/p/python/asm.c
+++ b/libr/lang/p/python/asm.c
@@ -54,15 +54,15 @@ static int py_assemble(RAsm *a, RAsmOp *op, const char *str) {
 static int py_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	int size = 0;
 	int seize = -1;
-	const char *opstr = "invalid";
+	r_strbuf_set (&op->buf_asm, opstr);
 	if (py_disassemble_cb) {
 		PyObject *arglist = Py_BuildValue ("(y#K)", buf, len, a->pc);
 		PyObject *result = PyEval_CallObject (py_disassemble_cb, arglist);
-		if (check_list_result (result, "assemble")) {
-			PyObject *len = PyList_GetItem (result, 0);
-			PyObject *str = PyList_GetItem (result, 1);
-			seize = PyNumber_AsSsize_t (len, NULL);
-			opstr = PySTRING_ASSTRING (str);
+		if (check_list_result (result, "disassemble")) {
+			PyObject *pylen = PyList_GetItem (result, 0);
+			PyObject *pystr = PyList_GetItem (result, 1);
+			seize = PyNumber_AsSsize_t (pylen, NULL);
+			r_strbuf_set (&op->buf_asm, PySTRING_ASSTRING (pystr));
 			Py_DECREF (result);
 		}
 	}
@@ -73,7 +73,7 @@ static int py_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	buflen = R_MIN (buflen, len);
 	char *res = calloc (buflen, 3);
 	if (res) {
-		r_asm_op_set_buf (op, buf, R_MIN (buflen, len));
+		r_asm_op_set_buf (op, buf, buflen);
 		free (res);
 	}
 	return seize;


### PR DESCRIPTION
`opstr` points to a string under Python control, which can be released before its value is copied into `op->buf_asm` (due to the call to `Py_DECREF` prior to calling `r_strbuf_set`).

The fix copies the value immediately, before decrementing Python's ref counter.