### PR TITLE
Improve Python performance by using MemoryView

### DIFF
--- a/libr/lang/p/python/anal.c
+++ b/libr/lang/p/python/anal.c
@@ -199,7 +199,9 @@ static int py_anal(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 				// Loading 'var' value if presented
 				r_strbuf_set (&op->esil, getS (dict, "esil"));
 				// TODO: Add opex support here
+				Py_DECREF (dict);
 			}
+			Py_DECREF (result);
 		} else {
 			eprintf ("Unknown type returned. List was expected.\n");
 			PyErr_Print();

--- a/libr/lang/p/python/anal.c
+++ b/libr/lang/p/python/anal.c
@@ -159,7 +159,7 @@ static int py_anal(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 		memset(op, 0, sizeof (RAnalOp));
 		// anal(addr, buf) - returns size + dictionary (structure) for RAnalOp
 		Py_buffer pybuf = {
-			.buf = buf,
+			.buf = (void *) buf, // Warning: const is lost when casting
 			.len = len,
 			.readonly = 1,
 			.ndim = 1,

--- a/libr/lang/p/python/anal.c
+++ b/libr/lang/p/python/anal.c
@@ -158,8 +158,16 @@ static int py_anal(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	if (py_anal_cb) {
 		memset(op, 0, sizeof (RAnalOp));
 		// anal(addr, buf) - returns size + dictionary (structure) for RAnalOp
-		PyObject *arglist = Py_BuildValue ("("BYTES_FMT")", buf, len, addr);
-		PyObject *result = PyObject_CallObject (py_anal_cb, arglist);
+		Py_buffer pybuf = {
+			.buf = buf,
+			.len = len,
+			.readonly = 1,
+			.ndim = 1,
+			.itemsize = 1,
+		};
+		PyObject *memview = PyMemoryView_FromBuffer (&pybuf);
+		PyObject *arglist = Py_BuildValue ("(NK)", memview, addr);
+		PyObject *result = PyEval_CallObject (py_anal_cb, arglist);
 		if (result && PyList_Check (result)) {
 			PyObject *len = PyList_GetItem (result, 0);
 			PyObject *dict = PyList_GetItem (result, 1);

--- a/libr/lang/p/python/asm.c
+++ b/libr/lang/p/python/asm.c
@@ -64,7 +64,7 @@ static int py_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 			.ndim = 1,
 			.itemsize = 1,
 		};
-		PyObject *memview = PyMemoryView_FromMemory (&pybuf);
+		PyObject *memview = PyMemoryView_FromBuffer (&pybuf);
 		PyObject *arglist = Py_BuildValue ("(NK)", memview, a->pc);
 		PyObject *result = PyEval_CallObject (py_disassemble_cb, arglist);
 		if (check_list_result (result, "disassemble")) {

--- a/libr/lang/p/python/asm.c
+++ b/libr/lang/p/python/asm.c
@@ -58,7 +58,7 @@ static int py_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	r_strbuf_set (&op->buf_asm, "invalid");
 	if (py_disassemble_cb) {
 		Py_buffer pybuf = {
-			.buf = buf,
+			.buf = (void *) buf, // Warning: const is lost when casting
 			.len = len,
 			.readonly = 1,
 			.ndim = 1,

--- a/libr/lang/p/python/asm.c
+++ b/libr/lang/p/python/asm.c
@@ -57,7 +57,15 @@ static int py_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	r_asm_op_init (op);
 	r_strbuf_set (&op->buf_asm, "invalid");
 	if (py_disassemble_cb) {
-		PyObject *arglist = Py_BuildValue ("(y#K)", buf, len, a->pc);
+		Py_buffer pybuf = {
+			.buf = buf,
+			.len = len,
+			.readonly = 1,
+			.ndim = 1,
+			.itemsize = 1,
+		};
+		PyObject *memview = PyMemoryView_FromMemory (&pybuf);
+		PyObject *arglist = Py_BuildValue ("(NK)", memview, a->pc);
 		PyObject *result = PyEval_CallObject (py_disassemble_cb, arglist);
 		if (check_list_result (result, "disassemble")) {
 			PyObject *pylen = PyList_GetItem (result, 0);


### PR DESCRIPTION
Python bindings for analysis and disassembly plugins passed buffers by using Py_BuildValue and passing the buffer as a string for Python consumption. This required Python to copy the whole buffer - a costly operation, especially when the buffer was large enough.

For a vast majority of architectures, copying the whole buffer is unnecessary, as the opcode can't be longer than several bytes (e.g., on x86 an opcode's size is limited to 15 bytes).

One option was passing `R_MIN (len, MAX_INSTRUCTION_SIZE)` instead of `len`, when creating the Python buffer. However, this has 2 problems: `MAX_INSTRUCTION_SIZE` is architecture-specific. We could retrieve it from the Python plugin on instantiation, but `RAnalPlugin` does not contain a proper field for storing it (instead, relying on `archinfo` to be used for retrieving this information). Calling `archinfo` every time to retrieve the maximum instruction size doesn't look right to me, and neither does storing the value statically in a global variable.

Instead, I rewrote the buffer passing code to use Python's buffer protocol and memory views - the recommended way of passing binary data to Python from C. By using the buffer protocol, we describe the buffer to Python (via a pointer to the buffer and a length), and Python looks directly at the memory provided, without copying it anywhere.

Caveat: the analysis and disassembly Python functions now receive a `memoryview` object instead of a `bytes` object. While it can be sliced as a regular array, it has some limitations. A `bytes` object based on it can be obtained by calling its `tobytes` method (which will initiate the copy - but can be called on a small slice, to save time and memory).

*****
Additionally, and unrelated to the subject of this PR, I added a couple of missing refcount decrements to the analysis code.