### PR TITLE
Drop python2 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 include config.mk
 
 PREFIX?=/usr
-PYTHON2_CONFIG=python2.7-config
-PYTHON3_CONFIG=python3.2-config
+PYTHON_CONFIG=python3.2-config
 
 ifneq ($(shell bsdtar -h 2>/dev/null|grep bsdtar),)
 TAR=bsdtar cJvf
@@ -11,7 +10,7 @@ else
 TAR=tar -cJvf
 endif
 
-W32PY="${HOME}/.wine/drive_c/Python27/"
+W32PY="${HOME}/.wine/drive_c/Python34/"
 
 ifneq ($(shell grep valac supported.langs 2>/dev/null),)
 INSTALL_TARGETS=install-vapi
@@ -57,15 +56,15 @@ check:
 
 check-w32:
 	if [ ! -d "${W32PY}/libs" ]; then \
-		wget http://www.python.org/ftp/python/2.7/python-2.7.msi ; \
-		msiexec /i python-2.7.msi /qn ; \
+		wget https://www.python.org/ftp/python/3.4.4/python-3.4.4.msi ; \
+		msiexec /i python-3.4.4.msi /qn ; \
 	fi
 
 w32:
 	cd python && ${MAKE} w32
 
 DSTNAME=radare2-bindings-w32-$(VERSION)
-DST=../$(DSTNAME)/Python27/Lib/site-packages/r2
+DST=../$(DSTNAME)/Python34/Lib/site-packages/r2
 
 w32dist:
 	rm -rf ../${DSTNAME}
@@ -115,12 +114,9 @@ vdoc_pkg:
 	# rsync -avz vdoc/* pancake@radare.org:/srv/http/radareorg/vdoc/
 
 # TODO: unspaguetti this targets
-.PHONY: python2 python3
-python2:
-	@-[ "`grep python supported.langs`" ] && ( cd python && ${MAKE} PYTHON_CONFIG=${PYTHON2_CONFIG}) || true
-
+.PHONY: python3
 python3:
-	@-[ "`grep python supported.langs`" ] && ( cd python && ${MAKE} PYTHON_CONFIG=${PYTHON3_CONFIG}) || true
+	@-[ "`grep python supported.langs`" ] && ( cd python && ${MAKE} PYTHON_CONFIG=${PYTHON_CONFIG}) || true
 
 ${ALANG}::
 	cd $@ && ${MAKE}

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ environment variable as follows:
 
 	$ ./configure --prefix=/usr --enable-devel
 	$ cd python
-	$ PYTHON_CONFIG=python2.7-config make
+	$ PYTHON_CONFIG=python3.2-config make
 	$ su -
-	# PYTHON_CONFIG=python2.7-config make install
+	# PYTHON_CONFIG=python3.2-config make install
 
 
 # RANDOM NOTES

--- a/genbind.py
+++ b/genbind.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 import sys
 import os.path
 import logging
@@ -6,11 +6,7 @@ import tempfile
 import argparse
 import subprocess
 from subprocess import call, check_output
-# Python 2 legacy hack
-try:
-    from StringIO import StringIO
-except:
-    from io import StringIO
+from io import StringIO
 
 # TODO: Better Python3 support
 

--- a/libr/lang/p/Makefile
+++ b/libr/lang/p/Makefile
@@ -62,37 +62,35 @@ endif
 all: $(LANGS)
 	@echo "LANG ${LANGS}"
 
-PYVER?=2
 ifeq ($(OSTYPE),windows)
 lang_python.${EXT_SO}:
-	${CC} ${CFLAGS} -I${HOME}/.wine/drive_c/Python27/include \
-	-L${HOME}/.wine/drive_c/Python27/libs \
+	${CC} ${CFLAGS} -I${HOME}/.wine/drive_c/Python34/include \
+	-L${HOME}/.wine/drive_c/Python34/libs \
 	$(shell pkg-config --cflags --libs r_reg r_core r_cons) \
-	${LDFLAGS_LIB} -o lang_python.${EXT_SO} python.c -lpython27
+	${LDFLAGS_LIB} -o lang_python.${EXT_SO} python.c -lpython34
 else
 PYCFG=../../../python-config-wrapper
-PYSO=lang_python$(PYVER).${EXT_SO}
-PYCFLAGS=$(shell PYVER=$(PYVER) ${PYCFG} --cflags) -DPYVER=${PYVER}
-PYLDFLAGS=$(shell PYVER=$(PYVER) ${PYCFG} --libs) 
-PYLDFLAGS+=-L$(shell PYVER=$(PYVER) ${PYCFG} --prefix)/lib
+PYCFLAGS=$(shell PYVER=3 ${PYCFG} --cflags) -DPYVER=3
+PYLDFLAGS=$(shell PYVER=3 ${PYCFG} --libs) 
+PYLDFLAGS+=-L$(shell PYVER=3 ${PYCFG} --prefix)/lib
 PYLDFLAGS+=${LDFLAGS_LIB}
 
-lang_python.$(EXT_SO) $(PYSO):
+lang_python.$(EXT_SO):
 	${CC} python.c ${CFLAGS} ${PYCFLAGS} ${PYLDFLAGS} \
 	$(shell pkg-config --cflags --libs r_reg r_core r_cons) \
-	${LDFLAGS} ${LDFLAGS_LIB} -fPIC -o $(PYSO)
+	${LDFLAGS} ${LDFLAGS_LIB} -fPIC -o lang_python.$(EXT_SO)
 endif
 
 py python:
-	rm -f $(PYSO)
-	$(MAKE) $(PYSO)
+	rm -f lang_python.$(EXT_SO)
+	$(MAKE) lang_python.$(EXT_SO)
 
 py-install python-install:
 	mkdir -p ${R2PM_PLUGDIR}
-	cp -f $(PYSO) ${R2PM_PLUGDIR}
+	cp -f lang_python.$(EXT_SO) ${R2PM_PLUGDIR}
 
 py-uninstall python-uninstall:
-	rm -f ${R2PM_PLUGDIR}/$(PYSO)
+	rm -f ${R2PM_PLUGDIR}/lang_python.$(EXT_SO)
 
 ifeq ($(HAVE_LIB_TCC),1)
 lang_tcc.${EXT_SO}: tcc.o
@@ -151,9 +149,9 @@ DUKTAPE_FILE=duktape-$(DUKTAPE_VER).tar.xz
 DUKTAPE_URL=http://duktape.org/$(DUKTAPE_FILE)
 
 p:
-	rm -f lang_python3.dylib
-	$(MAKE) lang_python.dylib PYVER=3
-	cp -f lang_python3.dylib ~/.local/share/radare2/plugins
+	rm -f lang_python.${EXT_SO}
+	$(MAKE) lang_python.${EXT_SO} PYVER=3
+	cp -f lang_python.${EXT_SO} ~/.local/share/radare2/plugins
 
 duk duktape-sync duk-sync sync-dunk sync-duktape:
 	rm -f $(DUKTAPE_FILE)

--- a/libr/lang/p/python.c
+++ b/libr/lang/p/python.c
@@ -13,15 +13,7 @@
 #if PY_MAJOR_VERSION<3
 #error Python 2 support is deprecated, use Python 3 instead
 #endif
-#define PyString_FromString PyBytes_FromString
-#define PyString_AsString PyBytes_AS_STRING
-#define PyINT_CHECK PyLong_Check
-#define PyINT_ASLONG PyLong_AsLong
-#define PySTRING_ASSTRING PyUnicode_AsUTF8
-#define PySTRING_FROMSTRING PyUnicode_FromString
 #define PLUGIN_NAME r_lang_plugin_python
-#define BYTES_FMT "y#iK"
-#define PyVersion "python3"
 
 static RCore *core = NULL;
 typedef struct {
@@ -42,7 +34,7 @@ static char *getS(PyObject *o, const char *name) {
 	if (!o) return NULL;
 	PyObject *res = PyDict_GetItemString (o, name);
 	if (!res) return NULL;
-	return strdup (PySTRING_ASSTRING (res));
+	return strdup (PyUnicode_AsUTF8 (res));
 }
 
 static st64 getI(PyObject *o, const char *name) {
@@ -114,12 +106,12 @@ static void Radare_dealloc(Radare* self) {
 static PyObject * Radare_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
 	Radare *self = (Radare *)type->tp_alloc (type, 0);
 	if (self) {
-		self->first = PySTRING_FROMSTRING ("");
+		self->first = PyUnicode_FromString ("");
 		if (!self->first) {
 			Py_DECREF (self);
 			return NULL;
 		}
-		self->last = PySTRING_FROMSTRING ("");
+		self->last = PyUnicode_FromString ("");
 		if (!self->last) {
 			Py_DECREF (self);
 			return NULL;
@@ -156,7 +148,7 @@ static PyObject *Radare_cmd(Radare* self, PyObject *args) {
 		return NULL;
 	}
 	str = r_core_cmd_str (core, cmd);
-	return PySTRING_FROMSTRING (str? str: py_nullstr);
+	return PyUnicode_FromString (str? str: py_nullstr);
 }
 
 static int Radare_init(Radare *self, PyObject *args, PyObject *kwds) {
@@ -337,7 +329,7 @@ static int init(RLang *lang) {
 	// Add a current directory to the PYTHONPATH
 	PyObject *sys = PyImport_ImportModule("sys");
 	PyObject *path = PyObject_GetAttrString(sys, "path");
-	PyList_Append(path, PySTRING_FROMSTRING("."));
+	PyList_Append(path, PyUnicode_FromString("."));
 	return true;
 }
 
@@ -355,10 +347,10 @@ static const char *help =
 	"  print r2.cmd(\"p8 10\");\n";
 
 RLangPlugin PLUGIN_NAME = {
-	.name = PyVersion,
+	.name = "python",
 	.alias = "python",
 	.ext = "py",
-	.desc = "Python language extension ("PyVersion")",
+	.desc = "Python language extension",
 	.init = &init,
 	.setup = &setup,
 	.fini = (void *)&fini,

--- a/libr/lang/p/python/anal.c
+++ b/libr/lang/p/python/anal.c
@@ -139,7 +139,7 @@ static int py_set_reg_profile(RAnal *a) {
 	if (py_set_reg_profile_cb) {
 		PyObject *result = PyObject_CallObject (py_set_reg_profile_cb, NULL);
 		if (result) {
-			profstr = PySTRING_ASSTRING (result);
+			profstr = PyUnicode_AsUTF8 (result);
 			return r_reg_set_profile_string (a->reg, profstr);
 		} else {
 			eprintf ("Unknown type returned. String was expected.\n");
@@ -216,7 +216,7 @@ static int py_archinfo(RAnal *a, int query) {
 		PyObject *arglist = Py_BuildValue ("(i)", query);
 		PyObject *result = PyEval_CallObject (py_archinfo_cb, arglist);
 		if (result) {
-			return PyINT_ASLONG (result); /* Python only returns long... */
+			return PyLong_AsLong (result); /* Python only returns long... */
 		}
 		eprintf ("Unknown type returned. Int was expected.\n");
 	}

--- a/libr/lang/p/python/asm.c
+++ b/libr/lang/p/python/asm.c
@@ -71,7 +71,7 @@ static int py_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 			PyObject *pylen = PyList_GetItem (result, 0);
 			PyObject *pystr = PyList_GetItem (result, 1);
 			seize = PyNumber_AsSsize_t (pylen, NULL);
-			r_strbuf_set (&op->buf_asm, PySTRING_ASSTRING (pystr));
+			r_strbuf_set (&op->buf_asm, PyUnicode_AsUTF8 (pystr));
 			Py_DECREF (result);
 		}
 	}

--- a/libr/lang/p/python/bin.c
+++ b/libr/lang/p/python/bin.c
@@ -82,12 +82,7 @@ static PyMethodDef PyBinFile_methods[] = {
 };
 
 PyTypeObject PyBinFileType = {
-#if PY_MAJOR_VERSION >= 3
 	PyVarObject_HEAD_INIT(NULL, 0)
-#else
-	PyObject_HEAD_INIT (NULL)
-	0,                         /*ob_size*/
-#endif
 	"binfile.BinFile",         /*tp_name*/
 	sizeof (PyBinFile),        /*tp_basicsize*/
 	0,                         /*tp_itemsize*/
@@ -127,14 +122,6 @@ PyTypeObject PyBinFileType = {
 	PyBinFile_new,             /* tp_new */
 };
 
-#if PY_MAJOR_VERSION < 3
-static void init_pybinfile_module(void) {
-	if (PyType_Ready (&PyBinFileType) < 0) {
-		return;
-	}
-	Py_InitModule3 ("binfile", PyBinFile_methods, "RBinFile python representation");
-}
-#else
 static PyModuleDef PyBinModule = {
 	PyModuleDef_HEAD_INIT,
 	"binfile",
@@ -153,7 +140,6 @@ static PyObject *init_pybinfile_module(void) {
 	}
 	return m;
 }
-#endif
 
 PyObject* create_PyBinFile(RBinFile *binfile)
 {

--- a/libr/lang/p/python/bin.c
+++ b/libr/lang/p/python/bin.c
@@ -19,12 +19,12 @@ static PyObject * PyBinFile_new(PyTypeObject *type, PyObject *args, PyObject *kw
 	PyBinFile *self = (PyBinFile *)type->tp_alloc (type, 0);
 	if (self) {
 		// Create empty buffers
-		self->bin_obj = PySTRING_FROMSTRING ("");
+		self->bin_obj = PyUnicode_FromString ("");
 		if (!self->bin_obj) {
 			Py_DECREF (self);
 			return NULL;
 		}
-		self->buf = PySTRING_FROMSTRING ("");
+		self->buf = PyUnicode_FromString ("");
 		if (!self->buf) {
 			Py_DECREF (self);
 			return NULL;
@@ -61,10 +61,10 @@ static PyObject *RBin_write_bytes(Radare* self, PyObject *args) {
 	char *buf = NULL;
 	ut64 addr = 0;
 	int buf_sz = 0;
-	if (!PyArg_ParseTuple (args, "(K,"BYTES_FMT")", &addr, &buf, &buf_sz)) {
+	if (!PyArg_ParseTuple (args, "(K,y#iK)", &addr, &buf, &buf_sz)) {
 		return NULL;
 	}
-	return PySTRING_FROMSTRING ("");
+	return PyUnicode_FromString ("");
 }
 
 static PyMemberDef PyBinFile_members[] = {
@@ -309,7 +309,7 @@ static bool py_load_bytes(RBinFile *arch, void **bin_obj, const ut8 *buf, ut64 s
 		// load_bytes(RBinFile, *binobj, buf, sz, loadaddr, sdb) - returns true/false
 		PyObject *pybinfile = create_PyBinFile(arch);
 		if (!pybinfile) return false;
-		PyObject *arglist = Py_BuildValue ("(O,"BYTES_FMT",L)", pybinfile, buf, sz, loadaddr);
+		PyObject *arglist = Py_BuildValue ("(O,y#iK,L)", pybinfile, buf, sz, loadaddr);
 		if (!arglist) {
 			PyErr_Print();
 			return false;
@@ -339,7 +339,7 @@ static bool py_check_bytes(const ut8 *buf, ut64 length)
 			return false;
 		}
 		// check_bytes(RBinFile) - returns true/false
-		PyObject *arglist = Py_BuildValue ("("BYTES_FMT")", buf, length);
+		PyObject *arglist = Py_BuildValue ("(y#iK)", buf, length);
 		if (!arglist) {
 			PyErr_Print();
 			return false;
@@ -400,7 +400,7 @@ static ut64 py_baddr(RBinFile *arch) {
 		PyObject *result = PyEval_CallObject (py_baddr_cb, arglist);
 		if (result && PyList_Check (result)) {
 			PyObject *res = PyList_GetItem (result, 0);
-			rres = PyINT_ASLONG (res);
+			rres = PyLong_AsLong (res);
 			if (rres) return rres;
 		} else {
 			PyErr_Print();

--- a/libr/lang/p/python/core.c
+++ b/libr/lang/p/python/core.c
@@ -15,8 +15,8 @@ static int py_core_call(void *user, const char *str) {
 		if (result) {
 			if (PyLong_Check (result)) {
 				return (int)PyLong_AsLong (result);
-			} else if (PyINT_CHECK (result)) {
-				return PyINT_ASLONG (result);
+			} else if (PyLong_Check (result)) {
+				return PyLong_AsLong (result);
 			} else if (PyUnicode_Check (result)) {
 				int n = PyUnicode_KIND (result);
 				switch (n) {
@@ -33,7 +33,7 @@ static int py_core_call(void *user, const char *str) {
 				}
 			} else
 			if (PyUnicode_Check (result)) {
-				str_res = PyString_AsString (result);
+				str_res = PyBytes_AS_STRING (result);
 			}
 			if (str_res) {
 				r_cons_print (str_res);

--- a/libr/lang/p/python/core.c
+++ b/libr/lang/p/python/core.c
@@ -18,9 +18,6 @@ static int py_core_call(void *user, const char *str) {
 			} else if (PyINT_CHECK (result)) {
 				return PyINT_ASLONG (result);
 			} else if (PyUnicode_Check (result)) {
-#if PY_MAJOR_VERSION < 3
-				str_res = PyUnicode_AS_DATA (result);
-#else
 				int n = PyUnicode_KIND (result);
 				switch (n) {
 				case 1:
@@ -34,17 +31,10 @@ static int py_core_call(void *user, const char *str) {
 					str_res = (char*)PyUnicode_4BYTE_DATA (result);
 					break;
 				}
-#endif
 			} else
-#if PY_MAJOR_VERSION < 3
-			if (PyString_Check (result)) {
-				str_res = PyString_AsString (result);
-			}
-#else
 			if (PyUnicode_Check (result)) {
 				str_res = PyString_AsString (result);
 			}
-#endif
 			if (str_res) {
 				r_cons_print (str_res);
 				return 1;

--- a/libr/lang/p/python/io.c
+++ b/libr/lang/p/python/io.c
@@ -127,11 +127,7 @@ static char *py_io_system(RIO *io, RIODesc *desc, const char *cmd) {
 		PyObject *result = PyEval_CallObject (py_io_system_cb, arglist);
 		if (result) {
 			if (
-#if PY_MAJOR_VERSION < 3
-			PyString_Check (result)
-#else
 			PyUnicode_Check (result)
-#endif
 			) {
 				res = PyString_AsString (result);
 			} else if (PyBool_Check (result)) {

--- a/libr/lang/p/python/io.c
+++ b/libr/lang/p/python/io.c
@@ -99,7 +99,7 @@ static int py_io_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 			size_t size = PyBytes_Size (result);
 			size_t limit = R_MIN (size, (size_t)count);
 			memset (buf, io->Oxff, limit);
-			memcpy (buf, PyString_AsString (result), limit);
+			memcpy (buf, PyBytes_AS_STRING (result), limit);
 			// eprintf ("result is a string DONE %d %d\n" , count, size);
 			count = (int)limit;
 		} else if (PyList_Check (result)) {
@@ -129,7 +129,7 @@ static char *py_io_system(RIO *io, RIODesc *desc, const char *cmd) {
 			if (
 			PyUnicode_Check (result)
 			) {
-				res = PyString_AsString (result);
+				res = PyBytes_AS_STRING (result);
 			} else if (PyBool_Check (result)) {
 				res = strdup (r_str_bool (result == Py_True));
 			} else if (PyLong_Check (result)) {

--- a/mp.py
+++ b/mp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 from distutils.sysconfig import get_python_lib;print(get_python_lib())
 #import os,sys
 #p='.'.join('/'.join(os.__file__.split('/')[:-1]).split('.')[:-1])

--- a/mp.py
+++ b/mp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from distutils.sysconfig import get_python_lib;print(get_python_lib())
 #import os,sys
 #p='.'.join('/'.join(os.__file__.split('/')[:-1]).split('.')[:-1])

--- a/python-config-wrapper
+++ b/python-config-wrapper
@@ -2,7 +2,6 @@
 # python-config wrapper trying to fix the python versioning hell
 # -- pancake
 
-if [ "${PYVER}" = 3 ]; then
 PCS="${PYTHON_CONFIG}
 	python3-config
 	python38-config
@@ -20,19 +19,6 @@ PCS="${PYTHON_CONFIG}
 	python32-config
 	python3.2-config
 	python-config"
-else
-PCS="${PYTHON_CONFIG}
-	python2-config
-	python28-config
-	python2.8-config
-	python27-config
-	python2.7-config
-	python26-config
-	python2.6-config
-	python25-config
-	python2.5-config
-	python-config"
-fi
 
 PYCFG=""
 

--- a/python-wrapper
+++ b/python-wrapper
@@ -3,16 +3,23 @@
 # -- pancake
 
 PCS="${PYTHON_CONFIG}
-	python2
-	python25
-	python2.5
-	python26
-	python2.6
-	python27
-	python2.7
-	python28
-	python2.8
+	python3
+	python38
+	python3.8
+	python37
+	python3.7
+	python36
+	python3.6
+	python35
+	python3.5
+	python34
+	python3.4
+	python33
+	python3.3
+	python32
+	python3.2
 	python"
+
 PYCFG=""
 
 for a in ${PCS} ; do
@@ -20,7 +27,7 @@ for a in ${PCS} ; do
 	if [ $? = 0 ]; then
 		PYCFG=$a
 		PY3=`$a --version 2>&1 | grep 'Python 3'`
-		[ -z "${PY3}" ] && break
+		[ -n "${PY3}" ] && break
 	fi
 done
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -8,7 +8,7 @@ include ../rules.mk
 tri:
 	valabind --swig -N Radare -o r_debug.i -m r_debug --vapidir ../../libr/vapi/ r_debug
 	swig -python -I/usr/include/libr r_debug.i
-	$(CC) r_debug_wrap.c -shared -fPIC -I /usr/include/libr -I /usr/include/python2.6/ -o _r_debug.so -lr_debug -lr_bp -lr_reg -lr_util
+	$(CC) r_debug_wrap.c -shared -fPIC -I /usr/include/libr -I /usr/include/python3.4/ -o _r_debug.so -lr_debug -lr_bp -lr_reg -lr_util
 
 mytest:
 	mkdir -p r2

--- a/python/test-leak.py
+++ b/python/test-leak.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*
 from r2.r_core import *
 

--- a/python/test-r_bp.py
+++ b/python/test-r_bp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from r2.r_core import RBreakpoint
 

--- a/python/test-r_bp.py
+++ b/python/test-r_bp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 
 from r2.r_core import RBreakpoint
 

--- a/python/test-r_core.py
+++ b/python/test-r_core.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 #
 # Python example for using loading fatmach0 binaries
 # test file:

--- a/python/test-r_core.py
+++ b/python/test-r_core.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Python example for using loading fatmach0 binaries
 # test file:

--- a/python/test-r_debug.py
+++ b/python/test-r_debug.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 #
 # Python example for using loading fatmach0 binaries
 # test file:

--- a/python/test-r_debug.py
+++ b/python/test-r_debug.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Python example for using loading fatmach0 binaries
 # test file:

--- a/python/test-ragdiff2.py
+++ b/python/test-ragdiff2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ragdiff2 - Copyright 2010-2015
 #   pancake <nopcode.org>

--- a/python/test/esil-step/step.py
+++ b/python/test/esil-step/step.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import time
 import r2pipe


### PR DESCRIPTION
As per #206, remove Python 2 support.

Note: I haven't completely tested the win32 compilation on Wine. I updated the download to use the latest Python 3 available as an MSI package (since later Python 3 versions fail to install successfully under Wine), but `make` fails due to other errors that I didn't feel like diving into. If anyone knows how the build of the w32 Python bindings works and can test its functionality, that'll be great.