### PR TITLE
Tidy up python.c

### DIFF
--- a/libr/lang/p/Makefile
+++ b/libr/lang/p/Makefile
@@ -76,7 +76,7 @@ PYLDFLAGS+=-L$(shell PYVER=3 ${PYCFG} --prefix)/lib
 PYLDFLAGS+=${LDFLAGS_LIB}
 
 lang_python.$(EXT_SO):
-	${CC} python.c ${CFLAGS} ${PYCFLAGS} ${PYLDFLAGS} \
+	${CC} python.c python/*.c ${CFLAGS} ${PYCFLAGS} ${PYLDFLAGS} \
 	$(shell pkg-config --cflags --libs r_reg r_core r_cons) \
 	${LDFLAGS} ${LDFLAGS_LIB} -fPIC -o lang_python.$(EXT_SO)
 endif

--- a/libr/lang/p/python.c
+++ b/libr/lang/p/python.c
@@ -1,72 +1,20 @@
 /* radare2 - LGPL - Copyright 2009-2019 - pancake */
 /* python extension for radare2's r_lang */
 
-#include <r_lib.h>
-#include <r_lang.h>
-#include <r_core.h>
-#undef _GNU_SOURCE
-#undef _XOPEN_SOURCE
-#undef _POSIX_C_SOURCE
-#undef PREFIX
-#include <Python.h>
-#include <structmember.h>
-#if PY_MAJOR_VERSION<3
-#error Python 2 support is deprecated, use Python 3 instead
-#endif
+#include "python/common.h"
+#include "python/core.h"
+#include "python/io.h"
+#include "python/asm.h"
+#include "python/anal.h"
+#include "python/bin.h"
 #define PLUGIN_NAME r_lang_plugin_python
-
-static RCore *core = NULL;
-typedef struct {
-	PyObject_HEAD
-	PyObject *first; /* first name */
-	PyObject *last;  /* last name */
-	int number;
-} Radare;
-
-static PyObject *getO(PyObject *o, const char *name) {
-	if (!o) return NULL;
-	PyObject *res = PyDict_GetItemString (o, name);
-	if (!res) return NULL;
-	return res;
-}
-
-static char *getS(PyObject *o, const char *name) {
-	if (!o) return NULL;
-	PyObject *res = PyDict_GetItemString (o, name);
-	if (!res) return NULL;
-	return strdup (PyUnicode_AsUTF8 (res));
-}
-
-static st64 getI(PyObject *o, const char *name) {
-	if (!o) return 0;
-	PyObject *res = PyDict_GetItemString (o, name);
-	if (!res) return 0;
-	return (st64) PyNumber_AsSsize_t (res, NULL);
-}
-
-static void *getF(PyObject *o, const char *name) {
-	if (!o) return NULL;
-	return PyDict_GetItemString (o, name);
-}
-
-static bool getB(PyObject *o, const char *name) {
-	if (!o) return NULL;
-	if (PyObject_IsTrue(o)) return true;
-	return false;
-}
-
-#include "python/io.c"
-#include "python/asm.c"
-#include "python/anal.c"
-#include "python/bin.c"
-#include "python/core.c"
 
 typedef struct {
 	const char *type;
 	PyObject* (*handler)(Radare*, PyObject*);
 } R2Plugins;
 
-static R2Plugins plugins[] = {
+R2Plugins plugins[] = {
 	{ "core", &Radare_plugin_core },
 	{ "asm", &Radare_plugin_asm },
 	{ "anal", &Radare_plugin_anal },

--- a/libr/lang/p/python/anal.c
+++ b/libr/lang/p/python/anal.c
@@ -2,8 +2,10 @@
 
 // Exporting the R_ANAL_* enum constants
 #include <r_reg.h>
+#include "anal.h"
+#include "core.h"
 
-static void py_export_anal_enum(PyObject *tp_dict) {
+void py_export_anal_enum(PyObject *tp_dict) {
 
 #define PYENUM(name) {\
 		PyObject *o = PyLong_FromLong(name); \
@@ -223,7 +225,7 @@ static int py_archinfo(RAnal *a, int query) {
 	return -1;
 }
 
-static void Radare_plugin_anal_free(RAnalPlugin *ap) {
+void Radare_plugin_anal_free(RAnalPlugin *ap) {
 	free ((char *)ap->name);
 	free ((char *)ap->arch);
 	free ((char *)ap->license);
@@ -231,7 +233,7 @@ static void Radare_plugin_anal_free(RAnalPlugin *ap) {
 	free (ap);
 }
 
-static PyObject *Radare_plugin_anal(Radare* self, PyObject *args) {
+PyObject *Radare_plugin_anal(Radare* self, PyObject *args) {
 	void *ptr = NULL;
 	PyObject *arglist = Py_BuildValue("(i)", 0);
 	PyObject *o = PyObject_CallObject (args, arglist);

--- a/libr/lang/p/python/anal.h
+++ b/libr/lang/p/python/anal.h
@@ -1,0 +1,13 @@
+#ifndef _PY_ANAL_H
+#define _PY_ANAL_H
+
+#include <r_anal.h>
+#include "common.h"
+
+void py_export_anal_enum(PyObject *tp_dict);
+
+void Radare_plugin_anal_free(RAnalPlugin *ap);
+
+PyObject *Radare_plugin_anal(Radare* self, PyObject *args);
+
+#endif /* _PY_ANAL_H */

--- a/libr/lang/p/python/anal.h
+++ b/libr/lang/p/python/anal.h
@@ -1,3 +1,5 @@
+/* radare - LGPL - Copyright 2017-2019 - pancake, xvilka, aronsky */
+
 #ifndef _PY_ANAL_H
 #define _PY_ANAL_H
 

--- a/libr/lang/p/python/asm.c
+++ b/libr/lang/p/python/asm.c
@@ -1,5 +1,8 @@
 /* radare - LGPL - Copyright 2009-2019 - pancake */
 
+#include "asm.h"
+#include "core.h"
+
 /* TODO : move into a struct stored in the plugin struct */
 static void *py_assemble_cb = NULL;
 static void *py_disassemble_cb = NULL;
@@ -86,7 +89,7 @@ static int py_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	return seize;
 }
 
-static void Radare_plugin_asm_free(RAsmPlugin *ap) {
+void Radare_plugin_asm_free(RAsmPlugin *ap) {
 	free ((char *)ap->name);
 	free ((char *)ap->arch);
 	free ((char *)ap->license);
@@ -94,7 +97,7 @@ static void Radare_plugin_asm_free(RAsmPlugin *ap) {
 	free (ap);
 }
 
-static PyObject *Radare_plugin_asm(Radare* self, PyObject *args) {
+PyObject *Radare_plugin_asm(Radare* self, PyObject *args) {
 	PyObject *arglist = Py_BuildValue ("(i)", 0);
 	PyObject *o = PyEval_CallObject (args, arglist);
 

--- a/libr/lang/p/python/asm.h
+++ b/libr/lang/p/python/asm.h
@@ -1,0 +1,11 @@
+#ifndef _PY_ASM_H
+#define _PY_ASM_H
+
+#include <r_asm.h>
+#include "common.h"
+
+void Radare_plugin_asm_free(RAsmPlugin *ap);
+
+PyObject *Radare_plugin_asm(Radare* self, PyObject *args);
+
+#endif /* _PY_ASM_H */

--- a/libr/lang/p/python/asm.h
+++ b/libr/lang/p/python/asm.h
@@ -1,3 +1,5 @@
+/* radare - LGPL - Copyright 2017-2019 - pancake, xvilka, aronsky */
+
 #ifndef _PY_ASM_H
 #define _PY_ASM_H
 

--- a/libr/lang/p/python/bin.c
+++ b/libr/lang/p/python/bin.c
@@ -1,5 +1,8 @@
 /* radare - LGPL - Copyright 2017-2019 - xvilka, pancake */
 
+#include "bin.h"
+#include "core.h"
+
 /* The structure, representing simplified version of RBinFile/RBinObject */
 typedef struct {
 	PyObject_HEAD
@@ -129,7 +132,7 @@ static PyModuleDef PyBinModule = {
 	NULL, NULL, NULL, NULL
 };
 
-static PyObject *init_pybinfile_module(void) {
+PyObject *init_pybinfile_module(void) {
 	if (PyType_Ready (&PyBinFileType) < 0) {
 		return NULL;
 	}
@@ -669,7 +672,7 @@ static RBinInfo *py_info(RBinFile *arch) {
 	return ret;
 }
 
-static void Radare_plugin_bin_free(RBinPlugin *bp) {
+void Radare_plugin_bin_free(RBinPlugin *bp) {
 	free ((char *)bp->name);
 	free ((char *)bp->desc);
 	free ((char *)bp->license);
@@ -678,7 +681,7 @@ static void Radare_plugin_bin_free(RBinPlugin *bp) {
 
 /* TODO: Add missing exported symbols */
 /* TODO: Fold the repeating code - may be add some macro? */
-static PyObject *Radare_plugin_bin(Radare* self, PyObject *args) {
+PyObject *Radare_plugin_bin(Radare* self, PyObject *args) {
 	void *ptr = NULL;
 	PyObject *arglist = Py_BuildValue("(i)", 0);
 	PyObject *o = PyEval_CallObject (args, arglist);

--- a/libr/lang/p/python/bin.h
+++ b/libr/lang/p/python/bin.h
@@ -1,0 +1,13 @@
+#ifndef _PY_BIN_H
+#define _PY_BIN_H
+
+#include <r_bin.h>
+#include "common.h"
+
+PyObject *init_pybinfile_module(void);
+
+void Radare_plugin_bin_free(RBinPlugin *bp);
+
+PyObject *Radare_plugin_bin(Radare* self, PyObject *args);
+
+#endif /* _PY_BIN_H */

--- a/libr/lang/p/python/bin.h
+++ b/libr/lang/p/python/bin.h
@@ -1,3 +1,5 @@
+/* radare - LGPL - Copyright 2017-2019 - pancake, xvilka, aronsky */
+
 #ifndef _PY_BIN_H
 #define _PY_BIN_H
 

--- a/libr/lang/p/python/common.c
+++ b/libr/lang/p/python/common.c
@@ -1,0 +1,33 @@
+#include "common.h"
+
+PyObject *getO(PyObject *o, const char *name) {
+	if (!o) return NULL;
+	PyObject *res = PyDict_GetItemString (o, name);
+	if (!res) return NULL;
+	return res;
+}
+
+char *getS(PyObject *o, const char *name) {
+	if (!o) return NULL;
+	PyObject *res = PyDict_GetItemString (o, name);
+	if (!res) return NULL;
+	return strdup (PyUnicode_AsUTF8 (res));
+}
+
+st64 getI(PyObject *o, const char *name) {
+	if (!o) return 0;
+	PyObject *res = PyDict_GetItemString (o, name);
+	if (!res) return 0;
+	return (st64) PyNumber_AsSsize_t (res, NULL);
+}
+
+void *getF(PyObject *o, const char *name) {
+	if (!o) return NULL;
+	return PyDict_GetItemString (o, name);
+}
+
+bool getB(PyObject *o, const char *name) {
+	if (!o) return NULL;
+	if (PyObject_IsTrue(o)) return true;
+	return false;
+}

--- a/libr/lang/p/python/common.c
+++ b/libr/lang/p/python/common.c
@@ -1,3 +1,5 @@
+/* radare - LGPL - Copyright 2017-2019 - pancake, xvilka, aronsky */
+
 #include "common.h"
 
 PyObject *getO(PyObject *o, const char *name) {

--- a/libr/lang/p/python/common.h
+++ b/libr/lang/p/python/common.h
@@ -1,0 +1,34 @@
+#ifndef _PY_COMMON_H
+#define _PY_COMMON_H
+#include <r_lib.h>
+#include <r_lang.h>
+
+#undef _GNU_SOURCE
+#undef _XOPEN_SOURCE
+#undef _POSIX_C_SOURCE
+#undef PREFIX
+
+#include <Python.h>
+#include <structmember.h>
+
+#if PY_MAJOR_VERSION<3
+#error Python 2 support is deprecated, use Python 3 instead
+#endif
+
+typedef struct {
+	PyObject_HEAD
+	PyObject *first; /* first name */
+	PyObject *last;  /* last name */
+	int number;
+} Radare;
+
+PyObject *getO(PyObject *o, const char *name);
+
+char *getS(PyObject *o, const char *name);
+
+st64 getI(PyObject *o, const char *name);
+
+void *getF(PyObject *o, const char *name);
+
+bool getB(PyObject *o, const char *name);
+#endif /* _PY_COMMON_H */

--- a/libr/lang/p/python/common.h
+++ b/libr/lang/p/python/common.h
@@ -1,3 +1,5 @@
+/* radare - LGPL - Copyright 2017-2019 - pancake, xvilka, aronsky */
+
 #ifndef _PY_COMMON_H
 #define _PY_COMMON_H
 #include <r_lib.h>

--- a/libr/lang/p/python/core.c
+++ b/libr/lang/p/python/core.c
@@ -1,8 +1,8 @@
 /* radare - LGPL - Copyright 2016-2019 - pancake */
 
-#include <r_core.h>
-#include <r_cmd.h>
-#include <r_cons.h>
+#include "core.h"
+
+RCore *core = NULL;
 
 /* TODO : move into a struct stored in the plugin struct */
 static void *py_core_call_cb = NULL;
@@ -44,14 +44,14 @@ static int py_core_call(void *user, const char *str) {
 	return 0;
 }
 
-static void Radare_plugin_core_free(RCorePlugin *ap) {
+void Radare_plugin_core_free(RCorePlugin *ap) {
 	free ((char *)ap->name);
 	free ((char *)ap->license);
 	free ((char *)ap->desc);
 	free (ap);
 }
 
-static PyObject *Radare_plugin_core(Radare* self, PyObject *args) {
+PyObject *Radare_plugin_core(Radare* self, PyObject *args) {
 	void *ptr = NULL;
 	PyObject *arglist = Py_BuildValue("(i)", 0);
 	PyObject *o = PyEval_CallObject (args, arglist);

--- a/libr/lang/p/python/core.h
+++ b/libr/lang/p/python/core.h
@@ -1,0 +1,13 @@
+#ifndef _PY_CORE_H
+#define _PY_CORE_H
+
+#include <r_core.h>
+#include "common.h"
+
+extern RCore *core;
+
+void Radare_plugin_core_free(RCorePlugin *ap);
+
+PyObject *Radare_plugin_core(Radare* self, PyObject *args);
+
+#endif /* _PY_CORE_H */

--- a/libr/lang/p/python/core.h
+++ b/libr/lang/p/python/core.h
@@ -6,7 +6,7 @@
 #include <r_core.h>
 #include "common.h"
 
-extern RCore *core;
+RCore *core;
 
 void Radare_plugin_core_free(RCorePlugin *ap);
 

--- a/libr/lang/p/python/core.h
+++ b/libr/lang/p/python/core.h
@@ -1,3 +1,5 @@
+/* radare - LGPL - Copyright 2017-2019 - pancake, xvilka, aronsky */
+
 #ifndef _PY_CORE_H
 #define _PY_CORE_H
 

--- a/libr/lang/p/python/io.c
+++ b/libr/lang/p/python/io.c
@@ -1,5 +1,8 @@
 /* radare - LGPL - Copyright 2009-2019 - pancake */
 
+#include "io.h"
+#include "core.h"
+
 /* r_io */
 static RIOPlugin *py_io_plugin = NULL;
 static void *py_io_open_cb = NULL;
@@ -145,14 +148,14 @@ static char *py_io_system(RIO *io, RIODesc *desc, const char *cmd) {
 	return res;
 }
 
-static void Radare_plugin_io_free(RAsmPlugin *ap) {
+void Radare_plugin_io_free(RIOPlugin *ap) {
 	free ((char *)ap->name);
 	free ((char *)ap->desc);
 	free ((char *)ap->license);
 	free (ap);
 }
 
-static PyObject *Radare_plugin_io(Radare* self, PyObject *args) {
+PyObject *Radare_plugin_io(Radare* self, PyObject *args) {
 	void *ptr = NULL;
 	PyObject *arglist = Py_BuildValue("(i)", 0);
 	PyObject *o = PyEval_CallObject (args, arglist);

--- a/libr/lang/p/python/io.h
+++ b/libr/lang/p/python/io.h
@@ -1,3 +1,5 @@
+/* radare - LGPL - Copyright 2017-2019 - pancake, xvilka, aronsky */
+
 #ifndef _PY_IO_H
 #define _PY_IO_H
 

--- a/libr/lang/p/python/io.h
+++ b/libr/lang/p/python/io.h
@@ -1,0 +1,11 @@
+#ifndef _PY_IO_H
+#define _PY_IO_H
+
+#include <r_io.h>
+#include "common.h"
+
+void Radare_plugin_io_free(RIOPlugin *ap);
+
+PyObject *Radare_plugin_io(Radare* self, PyObject *args);
+
+#endif /* _PY_IO_H */


### PR DESCRIPTION
python.c includes the other C files from the python subdirectory. This PR improves the situation by splitting things up into header files and compiling the different C files directly.