### PR TITLE
Enhance Python api

### DIFF
--- a/libr/lang/p/python/anal.c
+++ b/libr/lang/p/python/anal.c
@@ -179,6 +179,7 @@ static int py_anal(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RA
 				op->cycles = getI (dict, "cycles");
 				op->size = seize;
 				op->addr = getI (dict, "addr");
+				op->delay = getI (dict, "delay");
 				op->jump = getI (dict, "jump");
 				op->fail = getI (dict, "fail");
 				op->stackop = getI (dict, "stackop");

--- a/libr/lang/p/python/asm.c
+++ b/libr/lang/p/python/asm.c
@@ -110,6 +110,7 @@ PyObject *Radare_plugin_asm(Radare* self, PyObject *args) {
 	ap->license = getS (o, "license");
 	ap->desc = getS (o, "desc");
 	ap->bits = getI (o, "bits");
+	ap->endian = getI (o, "endian");
 	void *ptr = getF (o, "disassemble");
 	if (ptr) {
 		Py_INCREF (ptr);


### PR DESCRIPTION
Expose some more asm/anal fields to be used by python plugins. 
Ideally all members should available in Python. Since I can't test that right now, I'm just adding those that I am currently using for now.